### PR TITLE
Add field_opt for non-present fields with propagated decode errors

### DIFF
--- a/src/decode.mli
+++ b/src/decode.mli
@@ -59,6 +59,9 @@ module type S = sig
   (** Decode an object, requiring a particular field. *)
   val field : string -> 'a decoder -> 'a decoder
 
+  (** Decode an object, where a particular field may or may not be present. *)
+  val field_opt : string -> 'a decoder -> 'a option decoder
+
   (** Decode an object, requiring exactly one field. *)
   val single_field : (string -> 'a decoder) -> 'a decoder
 

--- a/test-ezjsonm/main.ml
+++ b/test-ezjsonm/main.ml
@@ -17,6 +17,26 @@ let ezjsonm_suite =
       ~decoder:(list string)
       ~input:{|["hello", "world"]|}
       ~expected:["hello"; "world"]
+  ; "field_opt present" >::
+    decoder_test
+      ~decoder:(field_opt "optional" string)
+      ~input:{|{"optional": "hello"}|}
+      ~expected:(Some "hello")
+  ; "field_opt missing" >::
+    decoder_test
+      ~decoder:(field_opt "optional" string)
+      ~input:{|{"missing": "hello"}|}
+      ~expected:None
+  ; "field_opt decode error" >::
+    fun _ ->
+      match decode_string (field_opt "optional" string) {|{"optional": 123}|} with
+      | Ok _ ->
+        assert_string
+          "expected decode error"
+      | Error e ->
+        assert_equal ~printer:CCFun.id
+          {|in field "optional": Expected a string, but got 123.|}
+          (Format.asprintf "%a" pp_error e)
   ]
 
 let ezjsonm_encoders_suite =


### PR DESCRIPTION
Adds `field_opt`, which allows a field to be missing, or expects the decode to succeed if present. This is different from `maybe (field ..` which allows the decode to fail and still returns None, which makes it hard to distinguish between the field actually not being sent, and decode failure.