### PR TITLE
Decoders for Sexplib

### DIFF
--- a/decoders-sexplib.opam
+++ b/decoders-sexplib.opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+synopsis: "Elm-inspired decoders for Ocaml"
+maintainer: "Matt Bray <mattjbray@gmail.com>"
+authors: ["Matt Bray <mattjbray@gmail.com>"]
+homepage: "https://github.com/mattjbray/ocaml-decoders"
+doc: "https://mattjbray.github.io/ocaml-decoders/decoders-sexplib"
+bug-reports: "https://github.com/mattjbray/ocaml-decoders/issues"
+license: "ISC"
+dev-repo: "git@github.com:mattjbray/ocaml-decoders.git"
+build: [["dune" "build" "-p" name "-j" jobs]]
+build-test: [["dune" "runtest" "-p" name "-j" jobs]]
+depends: [
+  "dune" {build}
+  "decoders"
+  "sexplib0"
+  "sexplib"
+]

--- a/src-bs/decoders_bs.ml
+++ b/src-bs/decoders_bs.ml
@@ -39,6 +39,8 @@ module Json_decodeable : Decode.Decodeable with type value = Js.Json.t = struct
         Js.Dict.entries dict
         |. Array.to_list
         |> List.map (fun (key, value) -> (Js.Json.string key, value)))
+
+  let to_list values = Js.Json.array (Array.of_list values)
 end
 
 module Decode = Decode.Make(Json_decodeable)

--- a/src-ezjsonm/decode.ml
+++ b/src-ezjsonm/decode.ml
@@ -50,6 +50,8 @@ module Ezjsonm_decodeable : Decode.Decodeable with type value = Ezjsonm.value = 
   let get_key_value_pairs = function
     | `O assoc -> Some (List.map (fun (key, value) -> (`String key, value)) assoc)
     | _ -> None
+
+  let to_list values = `A values
 end
 
 include Decode.Make(Ezjsonm_decodeable)

--- a/src-ocyaml/decode.ml
+++ b/src-ocyaml/decode.ml
@@ -72,6 +72,8 @@ module Yaml_decodeable : Decode.Decodeable with type value = Ocyaml.yaml = struc
   let get_key_value_pairs = function
     | Structure assoc -> Some assoc
     | _ -> None
+
+  let to_list values = Collection values
 end
 
 include Decode.Make(Yaml_decodeable)

--- a/src-sexplib/decode.ml
+++ b/src-sexplib/decode.ml
@@ -1,0 +1,42 @@
+open Decoders
+open Sexplib0
+
+module Sexplib_decodeable : Decode.Decodeable with type value = Sexp.t = struct
+  type value = Sexp.t
+
+  let pp fmt value =
+    Format.fprintf fmt "@[%a@]"
+      Sexp.pp_hum value
+
+  let of_string (input : string) : (value, string) CCResult.t =
+    try Ok (Sexplib.Sexp.of_string input) with
+    | Failure msg -> Error msg
+
+  let of_file (file : string) : (value, string) CCResult.t =
+    try Ok (Sexplib.Sexp.load_sexp file) with
+    | e -> Error (Printexc.to_string e)
+
+  let try_get f value =
+    try Some (f value) with
+    | Sexp_conv.Of_sexp_error _ -> None
+
+  let get_string = try_get Sexp_conv.string_of_sexp
+  let get_int = try_get Sexp_conv.int_of_sexp
+  let get_float = try_get Sexp_conv.float_of_sexp
+  let get_null = try_get Sexp_conv.unit_of_sexp
+  let get_bool = try_get Sexp_conv.bool_of_sexp
+
+  let get_list = function
+    | Sexp.List lst -> Some lst
+    | _ -> None
+
+  let get_key_value_pairs = function
+    | Sexp.List lst ->
+      lst |> CCList.map (function
+          | Sexp.List [key; value] -> Some (key, value)
+          | _ -> None)
+      |> CCList.all_some
+    | _ -> None
+end
+
+include Decode.Make(Sexplib_decodeable)

--- a/src-sexplib/decode.ml
+++ b/src-sexplib/decode.ml
@@ -37,6 +37,8 @@ module Sexplib_decodeable : Decode.Decodeable with type value = Sexp.t = struct
           | _ -> None)
       |> CCList.all_some
     | _ -> None
+
+  let to_list values = Sexp.List values
 end
 
 include Decode.Make(Sexplib_decodeable)

--- a/src-sexplib/decode.mli
+++ b/src-sexplib/decode.mli
@@ -1,0 +1,3 @@
+(** Turn S-expressions into Ocaml values via Sexplib. *)
+
+include Decoders.Decode.S with type value = Sexplib0.Sexp.t

--- a/src-sexplib/decode.mli
+++ b/src-sexplib/decode.mli
@@ -1,3 +1,13 @@
 (** Turn S-expressions into Ocaml values via Sexplib. *)
 
+(** Following the convention of [Sexplib0.Sexp_conv.hashtbl_of_sexp], we
+    consider an S-expression to be an "object" if it is a list of two-element
+    lists. For example:
+
+        ((field1 value2) (field2 value2))
+
+    Like YAML, fields of an object are not necessarily atoms. To handle these,
+    look for the primed combinators (e.g. [keys']).
+*)
+
 include Decoders.Decode.S with type value = Sexplib0.Sexp.t

--- a/src-sexplib/dune
+++ b/src-sexplib/dune
@@ -1,0 +1,7 @@
+(library
+ (name decoders_sexplib)
+ (public_name decoders-sexplib)
+ (libraries
+  decoders
+  sexplib
+  sexplib0))

--- a/src-sexplib/test/dune
+++ b/src-sexplib/test/dune
@@ -1,0 +1,6 @@
+(test
+ (name main)
+ (package decoders-sexplib)
+ (libraries
+  decoders-sexplib
+  oUnit))

--- a/src-sexplib/test/main.ml
+++ b/src-sexplib/test/main.ml
@@ -25,6 +25,14 @@ let sexplib_suite =
       ~decoder:(field_opt "optional" string)
       ~input:"()"
       ~expected:None
+  ; "uncons" >::
+    decoder_test
+      ~decoder:(string |> uncons (function
+          | "library" -> field "name" string
+          | _ -> fail "Expected 'library'"
+        ))
+      ~input:"(library (name decoders))"
+      ~expected:"decoders"
   ]
 
 let () =

--- a/src-sexplib/test/main.ml
+++ b/src-sexplib/test/main.ml
@@ -1,0 +1,34 @@
+open OUnit2
+
+let sexplib_suite =
+  let open Decoders_sexplib.Decode in
+
+  let decoder_test ~decoder ~input ~expected _test_ctxt =
+    match decode_string decoder input with
+    | Ok value -> assert_equal value expected
+    | Error error -> assert_string (Format.asprintf "%a" pp_error error)
+  in
+
+  "Sexplib" >:::
+  [ "list string" >::
+    decoder_test
+      ~decoder:(list string)
+      ~input:"(hello world)"
+      ~expected:["hello"; "world"]
+  ; "field_opt present" >::
+    decoder_test
+      ~decoder:(field_opt "optional" string)
+      ~input:"((optional hello))"
+      ~expected:(Some "hello")
+  ; "field_opt missing" >::
+    decoder_test
+      ~decoder:(field_opt "optional" string)
+      ~input:"()"
+      ~expected:None
+  ]
+
+let () =
+  "decoders" >:::
+  [ sexplib_suite
+  ]
+  |> run_test_tt_main

--- a/src-yojson/basic.ml
+++ b/src-yojson/basic.ml
@@ -43,6 +43,8 @@ module Json_decodeable : Decode.Decodeable with type value = Yojson.Basic.json =
   let get_key_value_pairs : value -> (value * value) list option = function
     | `Assoc assoc -> Some (List.map (fun (key, value) -> (`String key, value)) assoc)
     | _ -> None
+
+  let to_list values = `List values
 end
 
 module Decode = Decode.Make(Json_decodeable)

--- a/src-yojson/raw.ml
+++ b/src-yojson/raw.ml
@@ -45,6 +45,8 @@ module Json_decodeable : Decode.Decodeable with type value = Yojson.Raw.json = s
   let get_key_value_pairs : value -> (value * value) list option = function
     | `Assoc assoc -> Some (List.map (fun (key, value) -> (`Stringlit (Printf.sprintf "%S" key), value)) assoc)
     | _ -> None
+
+  let to_list values = `List values
 end
 
 module Decode = struct

--- a/src-yojson/safe.ml
+++ b/src-yojson/safe.ml
@@ -43,6 +43,8 @@ module Json_decodeable : Decode.Decodeable with type value = Yojson.Safe.json = 
   let get_key_value_pairs : value -> (value * value) list option = function
     | `Assoc assoc -> Some (List.map (fun (key, value) -> (`String key, value)) assoc)
     | _ -> None
+
+  let to_list values = `List values
 end
 
 module Decode = Decode.Make(Json_decodeable)

--- a/src/decode.ml
+++ b/src/decode.ml
@@ -25,6 +25,8 @@ module type Decodeable = sig
   val get_null : value -> unit option
   val get_list : value -> value list option
   val get_key_value_pairs : value -> (value * value) list option
+
+  val to_list : value list -> value
 end
 
 (** User-facing Decoder interface. *)
@@ -46,6 +48,7 @@ module type S = sig
   val list : 'a decoder -> 'a list decoder
   val list_filter : 'a option decoder -> 'a list decoder
   val index : int -> 'a decoder -> 'a decoder
+  val uncons : ('a -> 'b decoder) -> 'a decoder -> 'b decoder
   val field : string -> 'a decoder -> 'a decoder
   val field_opt : string -> 'a decoder -> 'a option decoder
   val single_field : (string -> 'a decoder) -> 'a decoder
@@ -380,6 +383,22 @@ module Make(Decodeable : Decodeable) : S with type value = Decodeable.value
               end
             | None -> (fail "Expected a list").run t
       }
+
+  let uncons (tail : 'a -> 'b decoder) (head : 'a decoder) : 'b decoder =
+    { run =
+        fun value ->
+          match Decodeable.get_list value with
+        | Some (x :: rest) ->
+          My_result.Infix.(
+            head.run x
+            |> My_result.map_err (tag_error "while consuming a list element")
+            >>= fun x ->
+            (tail x).run (Decodeable.to_list rest)
+            |> My_result.map_err (tag_error "after consuming a list element")
+          )
+        | Some [] -> (fail "Expected a non-empty list").run value
+        | None -> (fail "Expected a list").run value
+    }
 
   let rec at : string list -> 'a decoder -> 'a decoder = fun path decoder ->
     match path with

--- a/src/decode.mli
+++ b/src/decode.mli
@@ -57,6 +57,40 @@ module type S = sig
   (** Decode a collection, requiring a particular index. *)
   val index : int -> 'a decoder -> 'a decoder
 
+  (** [fst |> uncons rest] decodes the first element of a list using [fst], then
+      decodes the remainder of the list using [rest].
+
+      For example, to decode this s-expression:
+
+          (library
+            (name decoders))
+
+      we can use this decoder:
+
+          string |> uncons (function
+            | "library" -> field "name" string
+            | _ -> fail "Expected a library stanza")
+
+      As another example, say you have a JSON array that starts with a string,
+      then a bool, then a list of integers:
+
+          ["hello", true, 1, 2, 3, 4]
+
+      We could decode it like this:
+
+          let (>>=::) fst rest = uncons rest fst
+
+          let decoder : (string * bool * int list) decoder =
+            string >>=:: fun the_string ->
+            bool >>=:: fun the_bool ->
+            list int >>= fun the_ints ->
+            succeed (the_string, the_bool, the_ints)
+
+      (If you squint, the uncons operator [>>=::] kind of looks like the cons
+      operator [::].)
+  *)
+  val uncons : ('a -> 'b decoder) -> 'a decoder -> 'b decoder
+
   (** {1 Object primitives} *)
 
   (** Decode an object, requiring a particular field. *)
@@ -203,7 +237,7 @@ end
 
 (** {2} Creating a Decoder implementation
 
-    The following are useful only if you are creating a new Decoder implementation.
+    The following is useful only if you are creating a new Decoder implementation.
 *)
 
 (** Signature of things that can be decoded. *)
@@ -220,6 +254,8 @@ module type Decodeable = sig
   val get_null : value -> unit option
   val get_list : value -> value list option
   val get_key_value_pairs : value -> (value * value) list option
+
+  val to_list : value list -> value
 end
 
 (** Derive decoders for a [Decodeable.value]. *)


### PR DESCRIPTION
A few questions came up while trying to decode the `dune` file format:
```
(library
  (name decoders-sexplib)
  (libraries decoders sexplib0))
```

Firstly, we want to decode the first element of the list as a string, then the remaining elements together as an object. For this we introduce a new primitive, `uncons`.

Secondly, if we were to follow the convention in `Sexplib0.Sexp_conv.hashtbl_of_sexp`, we could consider an S-expression to be an "object" if it is a list of two-element lists, i.e.:
```
((key1 value2) 
 (key2 (value2 value3))
```

However, in a dune file, if the value of a field is a list, the parenthesis are omitted. So we accept that as an "object" too.

Using this, we can write a decoder for the `dune` file:

```ocaml
open Decoders_sexplib

type library = { name : string; libraries : string list }

let (>>=::) head tail = uncons tail head

let library : library decoder =
  string >>=:: function
  | "library" ->
    field "name" string >>= fun name ->
    field "libraries"
      (one_of
          [ ("list", list string)
          ; ("string", string >|= fun s -> [s])
          ])
    >>= fun libraries ->
    succeed { name; libraries }
  | _ -> fail "Expected 'library'"

```