### PR TITLE
Add <$> operator (map) to decode

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,0 @@
-vscode:
-  extensions:
-    - jaredly.reason-vscode@1.7.8:wz4m53rsmsFB4l8luCXrQw==

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,3 @@
+vscode:
+  extensions:
+    - jaredly.reason-vscode@1.7.8:wz4m53rsmsFB4l8luCXrQw==

--- a/src/decode.ml
+++ b/src/decode.ml
@@ -78,6 +78,7 @@ module type S = sig
     val (>|=) : 'a decoder -> ('a -> 'b) -> 'b decoder
     val (>>=) : 'a decoder -> ('a -> 'b decoder) -> 'b decoder
     val (<*>) : ('a -> 'b) decoder -> 'a decoder -> 'b decoder
+    val (<$>) : ('a -> 'b) -> 'a decoder -> 'b decoder
   end
 
   include module type of Infix
@@ -216,6 +217,7 @@ module Make(Decodeable : Decodeable) : S with type value = Decodeable.value
     let (>|=) x f = map f x
     let (>>=) x f = and_then f x
     let (<*>) f x = apply f x
+    let (<$>) = map
   end
 
   let maybe (decoder : 'a decoder) : 'a option decoder =

--- a/src/decode.mli
+++ b/src/decode.mli
@@ -224,6 +224,7 @@ module type S = sig
     val (>|=) : 'a decoder -> ('a -> 'b) -> 'b decoder
     val (>>=) : 'a decoder -> ('a -> 'b decoder) -> 'b decoder
     val (<*>) : ('a -> 'b) decoder -> 'a decoder -> 'b decoder
+    val (<$>) : ('a -> 'b) -> 'a decoder -> 'b decoder
   end
 
   include module type of Infix


### PR DESCRIPTION
This PR adds the <$> operator to decode in order to be able to use this haskell like format when decoding. For example:
```ocaml
type my_user =
  { name : string
  ; age : int
  }

let make_my_user  name age = { name, age }

let my_user_decoder : my_user decoder = 
  let open D in
  make_unregistered
  <$> field "name" string
  <*> field "age" int
  