### PR TITLE
add bs-specific `array` decoder

### DIFF
--- a/__tests__/decoders_bs_test.ml
+++ b/__tests__/decoders_bs_test.ml
@@ -17,6 +17,20 @@ let () =
 
 let () =
   describe
+    "decoders-bs decode array"
+    Expect.(
+      fun () ->
+        test
+          "array"
+          Decode.(
+            fun () ->
+              let json_str = {|["a", "b", "c"]|} in
+              let decoded = decode_string (array string) json_str in
+              expect decoded |> toEqual (Belt.Result.Ok [| "a"; "b"; "c" |])))
+
+
+let () =
+  describe
     "decoders-bs encode"
     Expect.(
       fun () ->
@@ -27,3 +41,17 @@ let () =
               let str = "Hello world" in
               let encoded = encode_string string str in
               expect encoded |> toEqual {|"Hello world"|}))
+
+
+let () =
+  describe
+    "decoders-bs encode array"
+    Expect.(
+      fun () ->
+        test
+          "string"
+          Encode.(
+            fun () ->
+              let x = [| "a"; "b"; "c" |] in
+              let encoded = encode_string (array string) x in
+              expect encoded |> toEqual {|["a","b","c"]|}))

--- a/src-bs/decoders_bs.mli
+++ b/src-bs/decoders_bs.mli
@@ -1,5 +1,17 @@
 (** Turn JSON values into Ocaml values. *)
 
-module Decode : Decoders.Decode.S with type value = Js.Json.t
+module Decode : sig
+  include Decoders.Decode.S with type value = Js.Json.t
 
-module Encode : Decoders.Encode.S with type value = Js.Json.t
+  (** {2 bs-specific decoders}*)
+
+  val array : 'a decoder -> 'a array decoder
+end
+
+module Encode : sig
+  include Decoders.Encode.S with type value = Js.Json.t
+
+  (** {2 bs-specific encoders}*)
+
+  val array : 'a encoder -> 'a array encoder
+end


### PR DESCRIPTION
Add an `array` decoder for bs - often we want to deal directly with arrays in JS and this saves the user having to convert to/from lists, and uses more primitive operations that are built into the browser (and so are hopefully more performant) during the actual decoding.