### PR TITLE
refactor: use a unboxed record for `Decoder.t`

### DIFF
--- a/src-bencode/decode.ml
+++ b/src-bencode/decode.ml
@@ -68,10 +68,11 @@ end
 include Decode.Make (Bencode_decodeable)
 
 let int64 : int64 decoder =
- {Decoder.dec=fun t ->
-  match t with
-  | Bencode.Integer value ->
-      Ok value
-  | _ ->
-      (fail "Expected an int64").dec t
- }
+  { Decoder.dec =
+      (fun t ->
+        match t with
+        | Bencode.Integer value ->
+            Ok value
+        | _ ->
+            (fail "Expected an int64").dec t )
+  }

--- a/src-bencode/decode.ml
+++ b/src-bencode/decode.ml
@@ -68,9 +68,10 @@ end
 include Decode.Make (Bencode_decodeable)
 
 let int64 : int64 decoder =
- fun t ->
+ {Decoder.dec=fun t ->
   match t with
   | Bencode.Integer value ->
       Ok value
   | _ ->
-      (fail "Expected an int64") t
+      (fail "Expected an int64").dec t
+ }

--- a/src-bs/bs_json.ml
+++ b/src-bs/bs_json.ml
@@ -60,16 +60,17 @@ module Decode = struct
   include D
 
   let array : 'a decoder -> 'a array decoder =
-   fun decoder t ->
+   fun decoder ->
+     {Decoder.dec=fun t ->
     match Js.Json.decodeArray t with
     | None ->
-        (fail "Expected an array") t
+        (fail "Expected an array").dec t
     | Some arr ->
         let oks, errs =
           arr
           |> Js.Array.reducei
                (fun (oks, errs) x i ->
-                 match decoder x with
+                 match decoder.dec x with
                  | Ok a ->
                      let _ = Js.Array.push a oks in
                      (oks, errs)
@@ -87,6 +88,7 @@ module Decode = struct
           Error
             (Error.tag_group "while decoding an array" (errs |> Array.to_list))
         else Ok oks
+     }
 end
 
 module Json_encodeable = struct

--- a/src-bs/bs_xml.ml
+++ b/src-bs/bs_xml.ml
@@ -177,7 +177,7 @@ module Decode = struct
   let from_result = of_result
 
   let tag (name : string) : unit decoder =
-    {{Decoder.dec=fun (v : value) ->
+    {Decoder.dec=fun (v : value) ->
     match v with
     | `El el when Element.tagName el = name ->
         Ok ()
@@ -252,7 +252,7 @@ module Decode = struct
     | `El el ->
         Element.child_nodes el
         |> My_list.filter_mapi (fun i v ->
-               match child v with
+               match child.dec v with
                | Error _ ->
                    None
                | Ok dec ->
@@ -274,7 +274,7 @@ module Decode = struct
     pick_children (pure child)
 
 
-  let decode_value decoder v = decoder v
+  let decode_value decoder v = decoder.dec v
 
   let of_string str =
     try Ok (`El (DOMParser.parse_xml str)) with

--- a/src-cbor/decode.ml
+++ b/src-cbor/decode.ml
@@ -41,25 +41,20 @@ include Decode.Make (Cbor_decodeable)
 
 (* CBOR-specific decoders *)
 
-let undefined : unit decoder ={Decoder.dec= function
-  | `Undefined ->
-      Ok ()
-  | json ->
-      (fail "Expected Undefined").dec json
-}
+let undefined : unit decoder =
+  { Decoder.dec =
+      (function
+      | `Undefined -> Ok () | json -> (fail "Expected Undefined").dec json )
+  }
 
 
-let simple : int decoder = {Decoder.dec=function
-  | `Simple i ->
-      Ok i
-  | json ->
-      (fail "Expected Simple").dec json
-}
+let simple : int decoder =
+  { Decoder.dec =
+      (function `Simple i -> Ok i | json -> (fail "Expected Simple").dec json)
+  }
 
 
-let bytes : string decoder = {Decoder.dec=function
-  | `Bytes b ->
-      Ok b
-  | json ->
-      (fail "Expected bytes").dec json
-}
+let bytes : string decoder =
+  { Decoder.dec =
+      (function `Bytes b -> Ok b | json -> (fail "Expected bytes").dec json)
+  }

--- a/src-cbor/decode.ml
+++ b/src-cbor/decode.ml
@@ -41,22 +41,25 @@ include Decode.Make (Cbor_decodeable)
 
 (* CBOR-specific decoders *)
 
-let undefined : unit decoder = function
+let undefined : unit decoder ={Decoder.dec= function
   | `Undefined ->
       Ok ()
   | json ->
-      (fail "Expected Undefined") json
+      (fail "Expected Undefined").dec json
+}
 
 
-let simple : int decoder = function
+let simple : int decoder = {Decoder.dec=function
   | `Simple i ->
       Ok i
   | json ->
-      (fail "Expected Simple") json
+      (fail "Expected Simple").dec json
+}
 
 
-let bytes : string decoder = function
+let bytes : string decoder = {Decoder.dec=function
   | `Bytes b ->
       Ok b
   | json ->
-      (fail "Expected bytes") json
+      (fail "Expected bytes").dec json
+}

--- a/src-ezxmlm/decode.ml
+++ b/src-ezxmlm/decode.ml
@@ -54,7 +54,8 @@ let and_then = bind
 let from_result = of_result
 
 let tag_ns (name : Xmlm.name) : unit decoder =
- Decoder.of_decode_fun @@ fun (v : value) ->
+  Decoder.of_decode_fun
+  @@ fun (v : value) ->
   match v with
   | `El ((name', _), _) when name = name' ->
       Ok ()
@@ -68,7 +69,8 @@ let tag_ns (name : Xmlm.name) : unit decoder =
 
 
 let tag (name : string) : unit decoder =
- Decoder.of_decode_fun @@ fun (v : value) ->
+  Decoder.of_decode_fun
+  @@ fun (v : value) ->
   match v with
   | `El (((_ns, name'), _), _) when name = name' ->
       Ok ()
@@ -82,7 +84,8 @@ let tag (name : string) : unit decoder =
 
 
 let any_tag_ns : Xmlm.name decoder =
- Decoder.of_decode_fun @@ fun (v : value) ->
+  Decoder.of_decode_fun
+  @@ fun (v : value) ->
   match v with
   | `El ((name, _), _) ->
       Ok name
@@ -91,7 +94,8 @@ let any_tag_ns : Xmlm.name decoder =
 
 
 let any_tag : string decoder =
- Decoder.of_decode_fun @@ fun (v : value) ->
+  Decoder.of_decode_fun
+  @@ fun (v : value) ->
   match v with
   | `El (((_ns, name), _), _) ->
       Ok name
@@ -100,11 +104,14 @@ let any_tag : string decoder =
 
 
 let data : string decoder =
- Decoder.of_decode_fun @@ fun (v : value) ->
+  Decoder.of_decode_fun
+  @@ fun (v : value) ->
   match v with `Data s -> Ok s | `El _ -> (fail "Expected Data").dec v
 
 
-let attrs_ns : Xmlm.attribute list decoder = Decoder.of_decode_fun @@ function
+let attrs_ns : Xmlm.attribute list decoder =
+  Decoder.of_decode_fun
+  @@ function
   | `El ((_tag, attrs), _children) ->
       Ok attrs
   | `Data _ as v ->
@@ -145,7 +152,9 @@ let attr (name : string) : string decoder =
       fail (Format.asprintf "Expected an attribute named %s" name)
 
 
-let pick_children (child : 'a decoder decoder) : 'a list decoder = Decoder.of_decode_fun @@ function
+let pick_children (child : 'a decoder decoder) : 'a list decoder =
+  Decoder.of_decode_fun
+  @@ function
   | `El ((name, _attrs), els) ->
       els
       |> My_list.filter_mapi (fun i el ->
@@ -162,8 +171,7 @@ let pick_children (child : 'a decoder decoder) : 'a list decoder = Decoder.of_de
       |> My_result.map_err
            (Error.tag_group (Format.asprintf "In tag %a" pp_name name))
   | `Data _ as v ->
-      (
-      fail "Expected a Tag").dec v
+      (fail "Expected a Tag").dec v
 
 
 let children (child : 'a decoder) : 'a list decoder = pick_children (pure child)

--- a/src-jsonaf/decoders_jsonaf.ml
+++ b/src-jsonaf/decoders_jsonaf.ml
@@ -4,12 +4,13 @@ module Decode = struct
   include Decode.Make (Jsonaf_decodeable)
 
   let number : string decoder =
-   fun t ->
+   {Decoder.dec=fun t ->
     match Jsonaf_decodeable.get_number t with
     | Some value ->
         Ok value
     | None ->
         Error (Decoders.Error.make ~context:t "not a number")
+   }
 end
 
 module Encode = struct

--- a/src-jsonaf/decoders_jsonaf.ml
+++ b/src-jsonaf/decoders_jsonaf.ml
@@ -4,13 +4,14 @@ module Decode = struct
   include Decode.Make (Jsonaf_decodeable)
 
   let number : string decoder =
-   {Decoder.dec=fun t ->
-    match Jsonaf_decodeable.get_number t with
-    | Some value ->
-        Ok value
-    | None ->
-        Error (Decoders.Error.make ~context:t "not a number")
-   }
+    { Decoder.dec =
+        (fun t ->
+          match Jsonaf_decodeable.get_number t with
+          | Some value ->
+              Ok value
+          | None ->
+              Error (Decoders.Error.make ~context:t "not a number") )
+    }
 end
 
 module Encode = struct

--- a/src-msgpck/decode.ml
+++ b/src-msgpck/decode.ml
@@ -48,50 +48,56 @@ end
 
 include Decode.Make (Msgpck_decodeable)
 
-let string_strict : string decoder = function
+let string_strict : string decoder = {Decoder.dec=function
   | M.String b ->
       Ok b
   | m ->
-      (fail "Expected string (strict)") m
+      (fail "Expected string (strict)").dec m
+}
 
 
-let bytes : string decoder = function
+let bytes : string decoder = {Decoder.dec=function
   | M.Bytes b ->
       Ok b
   | m ->
-      (fail "Expected bytes") m
+      (fail "Expected bytes").dec m
+}
 
-
-let int32 : _ decoder = function
+let int32 : _ decoder = {Decoder.dec=function
   | M.Int32 i ->
       Ok i
   | m ->
-      (fail "Expected int32") m
+      (fail "Expected int32").dec m
+}
 
-
-let int64 : _ decoder = function
+let int64 : _ decoder = {Decoder.dec=function
   | M.Int64 i ->
       Ok i
   | m ->
-      (fail "Expected int64") m
+      (fail "Expected int64").dec m
+}
 
 
-let uint32 : _ decoder = function
+let uint32 : _ decoder = {Decoder.dec=function
   | M.Uint32 i ->
       Ok i
   | m ->
-      (fail "Expected uint32") m
+      (fail "Expected uint32").dec m
+}
 
 
-let uint64 : _ decoder = function
+let uint64 : _ decoder ={Decoder.dec= function
   | M.Uint64 i ->
       Ok i
   | m ->
-      (fail "Expected uint64") m
+
+      (fail "Expected uint64").dec m
+}
 
 
-let ext : (int * string) decoder = function
+let ext : (int * string) decoder = {Decoder.dec=function
   | M.Ext (i, s) ->
       Ok (i, s)
   | m ->
-      (fail "Expected extension") m
+      (fail "Expected extension").dec m
+}

--- a/src-msgpck/decode.ml
+++ b/src-msgpck/decode.ml
@@ -48,56 +48,45 @@ end
 
 include Decode.Make (Msgpck_decodeable)
 
-let string_strict : string decoder = {Decoder.dec=function
-  | M.String b ->
-      Ok b
-  | m ->
-      (fail "Expected string (strict)").dec m
-}
+let string_strict : string decoder =
+  { Decoder.dec =
+      (function
+      | M.String b -> Ok b | m -> (fail "Expected string (strict)").dec m )
+  }
 
 
-let bytes : string decoder = {Decoder.dec=function
-  | M.Bytes b ->
-      Ok b
-  | m ->
-      (fail "Expected bytes").dec m
-}
-
-let int32 : _ decoder = {Decoder.dec=function
-  | M.Int32 i ->
-      Ok i
-  | m ->
-      (fail "Expected int32").dec m
-}
-
-let int64 : _ decoder = {Decoder.dec=function
-  | M.Int64 i ->
-      Ok i
-  | m ->
-      (fail "Expected int64").dec m
-}
+let bytes : string decoder =
+  { Decoder.dec =
+      (function M.Bytes b -> Ok b | m -> (fail "Expected bytes").dec m)
+  }
 
 
-let uint32 : _ decoder = {Decoder.dec=function
-  | M.Uint32 i ->
-      Ok i
-  | m ->
-      (fail "Expected uint32").dec m
-}
+let int32 : _ decoder =
+  { Decoder.dec =
+      (function M.Int32 i -> Ok i | m -> (fail "Expected int32").dec m)
+  }
 
 
-let uint64 : _ decoder ={Decoder.dec= function
-  | M.Uint64 i ->
-      Ok i
-  | m ->
-
-      (fail "Expected uint64").dec m
-}
+let int64 : _ decoder =
+  { Decoder.dec =
+      (function M.Int64 i -> Ok i | m -> (fail "Expected int64").dec m)
+  }
 
 
-let ext : (int * string) decoder = {Decoder.dec=function
-  | M.Ext (i, s) ->
-      Ok (i, s)
-  | m ->
-      (fail "Expected extension").dec m
-}
+let uint32 : _ decoder =
+  { Decoder.dec =
+      (function M.Uint32 i -> Ok i | m -> (fail "Expected uint32").dec m)
+  }
+
+
+let uint64 : _ decoder =
+  { Decoder.dec =
+      (function M.Uint64 i -> Ok i | m -> (fail "Expected uint64").dec m)
+  }
+
+
+let ext : (int * string) decoder =
+  { Decoder.dec =
+      (function
+      | M.Ext (i, s) -> Ok (i, s) | m -> (fail "Expected extension").dec m )
+  }

--- a/src-yojson/raw.ml
+++ b/src-yojson/raw.ml
@@ -74,27 +74,30 @@ module Decode = struct
 
   (* Yojson.Raw specific decoders *)
 
-  let stringlit : string decoder = function
+  let stringlit : string decoder = {Decoder.dec=function
     | `Stringlit value ->
         Ok value
     | json ->
-        (fail "Expected a string") json
+        (fail "Expected a string").dec json
 
+  }
 
-  let intlit : string decoder = function
+  let intlit : string decoder = {Decoder.dec=function
     | `Intlit value ->
         Ok value
     | json ->
-        (fail "Expected an int") json
+        (fail "Expected an int").dec json
+  }
 
 
-  let floatlit : string decoder = function
+  let floatlit : string decoder = {Decoder.dec=function
     | `Floatlit value ->
         Ok value
     | `Intlit value ->
         Ok value
     | json ->
-        (fail "Expected a float") json
+        (fail "Expected a float").dec json
+  }
 end
 
 module Json_encodeable = struct

--- a/src-yojson/raw.ml
+++ b/src-yojson/raw.ml
@@ -74,30 +74,34 @@ module Decode = struct
 
   (* Yojson.Raw specific decoders *)
 
-  let stringlit : string decoder = {Decoder.dec=function
-    | `Stringlit value ->
-        Ok value
-    | json ->
-        (fail "Expected a string").dec json
-
-  }
-
-  let intlit : string decoder = {Decoder.dec=function
-    | `Intlit value ->
-        Ok value
-    | json ->
-        (fail "Expected an int").dec json
-  }
+  let stringlit : string decoder =
+    { Decoder.dec =
+        (function
+        | `Stringlit value ->
+            Ok value
+        | json ->
+            (fail "Expected a string").dec json )
+    }
 
 
-  let floatlit : string decoder = {Decoder.dec=function
-    | `Floatlit value ->
-        Ok value
-    | `Intlit value ->
-        Ok value
-    | json ->
-        (fail "Expected a float").dec json
-  }
+  let intlit : string decoder =
+    { Decoder.dec =
+        (function
+        | `Intlit value -> Ok value | json -> (fail "Expected an int").dec json
+        )
+    }
+
+
+  let floatlit : string decoder =
+    { Decoder.dec =
+        (function
+        | `Floatlit value ->
+            Ok value
+        | `Intlit value ->
+            Ok value
+        | json ->
+            (fail "Expected a float").dec json )
+    }
 end
 
 module Json_encodeable = struct

--- a/src/decode.mli
+++ b/src/decode.mli
@@ -10,6 +10,4 @@ module type Decodeable = Sig.Decodeable
 
 (** Derive decoders for a [Decodeable.value]. *)
 module Make (M : Decodeable) :
-  Sig.S
-    with type value = M.value
-     and type 'a decoder = (M.value, 'a) Decoder.t
+  Sig.S with type value = M.value and type 'a decoder = (M.value, 'a) Decoder.t

--- a/src/decoder.ml
+++ b/src/decoder.ml
@@ -1,32 +1,40 @@
-type ('i, 'o) t = 'i -> ('o, 'i Error.t) result
+type ('i, 'o) t = { dec : 'i -> ('o, 'i Error.t) result } [@@unboxed]
 
-let pure x : ('i, 'o) t = fun _i -> Ok x
+let pure x : ('i, 'o) t = { dec = (fun _i -> Ok x) }
 
-let fail msg : ('i, 'o) t = fun i -> Error (Error.make ~context:i msg)
+let fail msg : ('i, 'o) t =
+  { dec = (fun i -> Error (Error.make ~context:i msg)) }
 
-let fail_with e : ('i, 'o) t = fun _i -> Error e
 
-let of_result = function Ok o -> pure o | Error e -> fail_with e
+let fail_with e : ('i, 'o) t = { dec = (fun _i -> Error e) }
+
+let of_result res = { dec = (fun _i -> res) }
 
 let bind (f : 'a -> ('i, 'b) t) (x : ('i, 'a) t) : ('i, 'b) t =
- fun i -> match x i with Ok y -> f y i | Error e -> Error e
+  { dec =
+      (fun i -> match x.dec i with Ok y -> (f y).dec i | Error e -> Error e)
+  }
 
 
 let map (f : 'a -> 'b) (x : ('i, 'a) t) : ('i, 'b) t =
- fun i -> match x i with Ok y -> Ok (f y) | Error e -> Error e
+  { dec = (fun i -> match x.dec i with Ok y -> Ok (f y) | Error e -> Error e)
+  }
 
 
 let map_err (f : 'i Error.t -> 'i Error.t) (x : ('i, 'o) t) : ('i, 'o) t =
- fun i -> match x i with Ok y -> Ok y | Error e -> Error (f e)
+  { dec = (fun i -> match x.dec i with Ok y -> Ok y | Error e -> Error (f e))
+  }
 
 
 let apply (f : ('i, 'a -> 'b) t) (x : ('i, 'a) t) : ('i, 'b) t =
- fun i ->
-  match f i with
-  | Ok f ->
-    (match x i with Ok x -> Ok (f x) | Error e -> Error e)
-  | Error e ->
-      Error e
+  { dec =
+      (fun i ->
+        match f.dec i with
+        | Ok f ->
+          (match x.dec i with Ok x -> Ok (f x) | Error e -> Error e)
+        | Error e ->
+            Error e )
+  }
 
 
 module Infix = struct
@@ -49,45 +57,54 @@ end
 
 let fix (f : ('i, 'a) t -> ('i, 'a) t) : ('i, 'a) t =
   let rec p = lazy (f r)
-  and r value = (Lazy.force p) value in
+  and r = { dec = (fun value -> (Lazy.force p).dec value) } in
   r
 
 
-let value : ('i, 'i) t = fun i -> Ok i
+let value : ('i, 'i) t = { dec = (fun i -> Ok i) }
 
 let maybe (x : ('i, 'a) t) : ('i, 'a option) t =
- fun i -> match x i with Ok x -> Ok (Some x) | Error _ -> Ok None
+  { dec =
+      (fun i -> match x.dec i with Ok x -> Ok (Some x) | Error _ -> Ok None)
+  }
 
 
 let one_of (xs : ('i, 'o) t list) : ('i, 'o) t =
- fun i ->
-  let rec aux errors = function
-    | x :: xs ->
-      (match x i with Ok o -> Ok o | Error e -> aux (e :: errors) xs)
-    | [] ->
-        Error (Error.group (List.rev errors))
-  in
-  aux [] xs
+  { dec =
+      (fun i ->
+        let rec aux errors = function
+          | x :: xs ->
+            (match x.dec i with Ok o -> Ok o | Error e -> aux (e :: errors) xs)
+          | [] ->
+              Error (Error.group (List.rev errors))
+        in
+        aux [] xs )
+  }
 
 
 let pick : ('i, ('i, 'o) t) t list -> ('i, 'o) t =
- fun decoders input ->
-  let rec go errors = function
-    | decoder :: rest ->
-      ( match decoder input with
-      | Ok dec ->
-        (* use [dec] and drop errors *)
-        (match dec input with Ok _ as x -> x | Error e -> Error e)
-      | Error error ->
-          go (error :: errors) rest )
-    | [] ->
-        Error (Error.group errors)
-  in
-  go [] decoders
+ fun decoders ->
+  { dec =
+      (fun input ->
+        let rec go errors = function
+          | decoder :: rest ->
+            ( match decoder.dec input with
+            | Ok dec ->
+              (* use [dec] and drop errors *)
+              (match dec.dec input with Ok _ as x -> x | Error e -> Error e)
+            | Error error ->
+                go (error :: errors) rest )
+          | [] ->
+              Error (Error.group errors)
+        in
+        go [] decoders )
+  }
 
 
 let of_to_opt (to_opt : 'i -> 'o option) fail : ('i, 'o) t =
- fun i -> match to_opt i with Some o -> Ok o | None -> fail i
+  { dec = (fun i -> match to_opt i with Some o -> Ok o | None -> fail i) }
 
 
-let decode_sub v dec = of_result (dec v)
+let decode_sub v dec = of_result (dec.dec v)
+
+let[@inline] of_decode_fun dec = { dec }

--- a/src/decoder.mli
+++ b/src/decoder.mli
@@ -31,7 +31,7 @@ module Infix : sig
 
   val ( <*> ) : ('i, 'a -> 'b) t -> ('i, 'a) t -> ('i, 'b) t
 
-  include Shims_let_ops_.S with type ('i, 'o) t_let = ('i, 'o) t
+  include Shims_let_ops_.S with type ('i, 'o) t_let := ('i, 'o) t
 end
 
 val fix : (('i, 'a) t -> ('i, 'a) t) -> ('i, 'a) t

--- a/src/decoder.mli
+++ b/src/decoder.mli
@@ -3,7 +3,7 @@
     - consumes a value of type ['i]
     - produces a value of type ['o] or an error of type ['i Error.t]
  *)
-type ('i, 'o) t = 'i -> ('o, 'i Error.t) result
+type ('i, 'o) t = { dec : 'i -> ('o, 'i Error.t) result } [@@unboxed]
 
 val pure : 'o -> ('i, 'o) t
 (** [pure x] always succeeds with [x] *)
@@ -14,15 +14,13 @@ val fail : string -> ('i, 'o) t
 val fail_with : 'i Error.t -> ('i, 'o) t
 (** [fail_with e] always fails with [e] *)
 
-val of_result :
-  ('o, 'i Error.t) Util.My_result.t -> ('i, 'o) t
+val of_result : ('o, 'i Error.t) Util.My_result.t -> ('i, 'o) t
 
 val bind : ('a -> ('i, 'b) t) -> ('i, 'a) t -> ('i, 'b) t
 
 val map : ('a -> 'b) -> ('i, 'a) t -> ('i, 'b) t
 
-val map_err :
-  ('i Error.t -> 'i Error.t) -> ('i, 'o) t -> ('i, 'o) t
+val map_err : ('i Error.t -> 'i Error.t) -> ('i, 'o) t -> ('i, 'o) t
 
 val apply : ('i, 'a -> 'b) t -> ('i, 'a) t -> ('i, 'b) t
 
@@ -50,3 +48,5 @@ val of_to_opt :
   ('i -> 'o option) -> ('i -> ('o, 'i Error.t) result) -> ('i, 'o) t
 
 val decode_sub : 'a -> ('a, 'b) t -> ('a, 'b) t
+
+val of_decode_fun : ('i -> ('o, 'i Error.t) result) -> ('i, 'o) t


### PR DESCRIPTION
this should improve error messages for users, because it won't present them with the unfolded function+result type. It makes type errors simpler.