### PR TITLE
Add a float decoder which trims whitespace.

### DIFF
--- a/src-bs/bs_xml.ml
+++ b/src-bs/bs_xml.ml
@@ -210,6 +210,36 @@ module Decode = struct
     }
 
 
+  let float : float decoder =
+    data
+    >>= fun s ->
+    match s |> String.trim |> float_of_string_opt with
+    | None ->
+        fail "Expected a float"
+    | Some f ->
+        succeed f
+
+
+  let int : int decoder =
+    data
+    >>= fun s ->
+    match s |> String.trim |> int_of_string_opt with
+    | None ->
+        fail "Expected an int"
+    | Some f ->
+        succeed f
+
+
+  let bool : bool decoder =
+    data
+    >>= fun s ->
+    match s |> String.trim |> bool_of_string_opt with
+    | None ->
+        fail "Expected a bool"
+    | Some f ->
+        succeed f
+
+
   let attr_opt name : string option decoder =
     { Decoder.dec =
         (fun (v : value) ->

--- a/src-ezxmlm/decode.ml
+++ b/src-ezxmlm/decode.ml
@@ -109,14 +109,34 @@ let data : string decoder =
   match v with `Data s -> Ok s | `El _ -> (fail "Expected Data").dec v
 
 
-let float_decoder : float decoder =
-  Decoder.of_decode_fun
-  @@ fun (v : value) ->
-  match v with
-  | `Data s ->
-      Ok (s |> String.trim |> float_of_string)
-  | `El _ ->
-      (fail "Expected Data").dec v
+let float : float decoder =
+  data
+  >>= fun s ->
+  match s |> String.trim |> float_of_string_opt with
+  | None ->
+      fail "Expected a float"
+  | Some f ->
+      succeed f
+
+
+let int : int decoder =
+  data
+  >>= fun s ->
+  match s |> String.trim |> int_of_string_opt with
+  | None ->
+      fail "Expected an int"
+  | Some f ->
+      succeed f
+
+
+let bool : bool decoder =
+  data
+  >>= fun s ->
+  match s |> String.trim |> bool_of_string_opt with
+  | None ->
+      fail "Expected a bool"
+  | Some f ->
+      succeed f
 
 
 let attrs_ns : Xmlm.attribute list decoder =

--- a/src-ezxmlm/decode.ml
+++ b/src-ezxmlm/decode.ml
@@ -109,6 +109,16 @@ let data : string decoder =
   match v with `Data s -> Ok s | `El _ -> (fail "Expected Data").dec v
 
 
+let float_decoder : float decoder =
+  Decoder.of_decode_fun
+  @@ fun (v : value) ->
+  match v with
+  | `Data s ->
+      Ok (s |> String.trim |> float_of_string)
+  | `El _ ->
+      (fail "Expected Data").dec v
+
+
 let attrs_ns : Xmlm.attribute list decoder =
   Decoder.of_decode_fun
   @@ function

--- a/src/xml.ml
+++ b/src/xml.ml
@@ -26,6 +26,10 @@ module type Decode = sig
   val data : string decoder
   (** Decode a [string]. *)
 
+  val float_decoder : float decoder
+  (** Decode a [float] in a data node after stripping whitespace. The advantage of using [float_decoder] is that it automatically takes care of trimming whitespace, 
+   which is useful since a float is not whitespace sensitive.  *)
+
   val tag : string -> unit decoder
   (** Assert the name of the current tag. *)
 

--- a/src/xml.ml
+++ b/src/xml.ml
@@ -26,9 +26,15 @@ module type Decode = sig
   val data : string decoder
   (** Decode a [string]. *)
 
-  val float_decoder : float decoder
+  val float : float decoder
   (** Decode a [float] in a data node after stripping whitespace. The advantage of using [float_decoder] is that it automatically takes care of trimming whitespace, 
    which is useful since a float is not whitespace sensitive.  *)
+
+  val int : int decoder
+  (** Decode an [int] in a data node after stripping whitespace. *)
+
+  val bool : bool decoder
+  (** Decode a [bool] in a data node after stripping whitespace.  *)
 
   val tag : string -> unit decoder
   (** Assert the name of the current tag. *)

--- a/test-ezxmlm/test_ezxmlm_decode.expected
+++ b/test-ezxmlm/test_ezxmlm_decode.expected
@@ -15,4 +15,6 @@ Comments are skipped:
 Comments are skipped:
   
 
-More data, even more data 0.750000
+More data, even more data 
+
+0.750000

--- a/test-ezxmlm/test_ezxmlm_decode.expected
+++ b/test-ezxmlm/test_ezxmlm_decode.expected
@@ -15,4 +15,4 @@ Comments are skipped:
 Comments are skipped:
   
 
-More data, even more data 
+More data, even more data 0.750000

--- a/test-ezxmlm/test_ezxmlm_decode.ml
+++ b/test-ezxmlm/test_ezxmlm_decode.ml
@@ -221,7 +221,7 @@ let () =
   let ret = decode_string root_decoder xml_str in
   match ret with
   | Ok fld ->
-      printf "%a" CCFormat.(list ~sep:(return ",") string) fld
+      printf "%a@.@." CCFormat.(list ~sep:(return ",") string) fld
       (* this prints "More data, even more data" *)
   | Error e ->
       failwith @@ string_of_error e
@@ -244,7 +244,7 @@ let () =
   let root_decoder : float list decoder =
     tag "root"
     >>= fun () ->
-    pick_children (tag "node" >>= fun () -> pure @@ children float_decoder)
+    pick_children (tag "node" >>= fun () -> pure @@ children float)
     >|= List.concat
   in
   let ret = decode_string root_decoder xml_str in

--- a/test-ezxmlm/test_ezxmlm_decode.ml
+++ b/test-ezxmlm/test_ezxmlm_decode.ml
@@ -225,3 +225,33 @@ let () =
       (* this prints "More data, even more data" *)
   | Error e ->
       failwith @@ string_of_error e
+
+
+(* Example 5 *)
+
+let () =
+  let open Decoders_ezxmlm.Decode in
+  let xml_str = {|<root> 
+  <node>
+
+
+
+  0.75
+
+  </node>
+  
+  </root>|} in
+  let root_decoder : float list decoder =
+    tag "root"
+    >>= fun () ->
+    pick_children (tag "node" >>= fun () -> pure @@ children float_decoder)
+    >|= List.concat
+  in
+  let ret = decode_string root_decoder xml_str in
+  match ret with
+  | Ok [ fld ] ->
+      printf "%f" fld
+  | Error e ->
+      failwith @@ string_of_error e
+  | _ ->
+      failwith "failed!"


### PR DESCRIPTION
Not sure if this is good to have or not, but I did wish something like this existed back when I was doing `children data` and doing `float_of_string` on the decoded output.  