### PR TITLE
Remove lazy

### DIFF
--- a/src/decoder.ml
+++ b/src/decoder.ml
@@ -56,8 +56,8 @@ module Infix = struct
 end
 
 let fix (f : ('i, 'a) t -> ('i, 'a) t) : ('i, 'a) t =
-  let rec p = lazy (f r)
-  and r = { dec = (fun value -> (Lazy.force p).dec value) } in
+  let rec p () = f r
+  and r = { dec = (fun value -> (p ()).dec value) } in
   r
 
 

--- a/src/encode.ml
+++ b/src/encode.ml
@@ -90,9 +90,7 @@ module Make (E : Encodeable) : S with type value = E.value = struct
 
   let key_value_pairs' : 'k encoder -> 'v encoder -> ('k * 'v) list encoder =
    fun key_encoder value_encoder xs ->
-    xs
-    |> List.map (fun (k, v) -> (key_encoder k, value_encoder v))
-    |> obj'
+    xs |> List.map (fun (k, v) -> (key_encoder k, value_encoder v)) |> obj'
 
 
   let obj xs = key_value_pairs' string (fun x -> x) xs


### PR DESCRIPTION
`Lazy.force` is not thread safe, but we don't really need `lazy` here - we can just use `fun ()`.