### PR TITLE
Add missing v in decoders-jsonaf bound and regenerate opam file

### DIFF
--- a/decoders-jsonaf.opam
+++ b/decoders-jsonaf.opam
@@ -15,7 +15,7 @@ depends: [
   "dune" {>= "3.1"}
   "ocaml" {>= "4.10.0"}
   "decoders" {= version}
-  "jsonaf" {>= "0.15.0"}
+  "jsonaf" {>= "v0.15.0"}
   "odoc" {with-doc}
   "ounit2" {with-test}
 ]

--- a/dune-project
+++ b/dune-project
@@ -56,7 +56,7 @@
  (depends
   (ocaml (>= 4.10.0))
   (decoders (= :version))
-  (jsonaf (>= 0.15.0))
+  (jsonaf (>= v0.15.0))
   (odoc :with-doc)
   (ounit2 :with-test)))
 


### PR DESCRIPTION
`jsonaf` uses a naming scheme where versions are prefixed with `v` and hence bounds should use it for correct version comparisons. Spotted upstream in the opam-repo.